### PR TITLE
Hide image when loading on firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@ img {
   height: 18rem;
   width: 18rem;
 }
+img:-moz-loading {
+  visibility: hidden;
+}
 </style>
 <body>
   <a href="https://github.com/fogo-sh/">


### PR DESCRIPTION
# Description

Resolves an issue where while loading the image will display the unstyled alt text for a second, by hiding the image while loading.

Chromium-based browsers handle this properly by gradually rendering the image as it's loaded. Firefox supposedly implemented this same behaviour but I'm on the latest version and there's no signs of it 🤷 

Relevant [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1472637).

I tried playing around with things such as preload (hence the branch name), but none of them actually helped this case.

# Before

https://user-images.githubusercontent.com/1741548/207468936-bb953efc-2e31-4216-b963-b70e50a8b773.mov

# After

https://user-images.githubusercontent.com/1741548/207469039-2f9da953-d08d-4bb9-97ad-436d183f0608.mov
